### PR TITLE
Add Gitlab provider. Fix regex generation for Github.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Github provider hostname is now configured with `githubinator.provider.github.hostname` setting instead of `githubinator.provider.github`.
 
+### Fixed
+
+- Fix regex creation for Github provider so hostname configured in settings is used to match origins.
+
 ## 0.1.0 - 2019-02-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `githubinator.enable_context_menu` option to disable/enable access to githubinator in the context menu.
+- Gitlab provider with `githubinator.provider.gitlab.hostname` setting for configuring match
+
+### Changed
+
+- Github provider hostname is now configured with `githubinator.provider.github.hostname` setting instead of `githubinator.provider.github`.
 
 ## 0.1.0 - 2019-02-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `githubinator.enable_context_menu` option to disable/enable access to githubinator in the context menu.
-- Gitlab provider with `githubinator.provider.gitlab.hostname` setting for configuring match
+- Gitlab provider with `githubinator.provider.gitlab.hostname` setting for configuring match.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ With `vsce` installed from NPM (`yarn global add vsce`), clone [this repo](https
 ## Extension Settings
 
 - `githubinator.default_remote`: The default remote branch for a repository. (default: `"origin"`)
-- `githubinator.providers.github`: The hostname for identifying a Github origin and building a URL. (default: `"github.com"`)
+- `githubinator.providers.github.hostname`: The hostname for identifying a Github origin and building a URL. (default: `"github.com"`)
+- `githubinator.providers.gitlab.hostname`: The hostname for identifying a Gitlab origin and building a url. (default: `"gitlab.com"`)
 
 ## Known Issues
 

--- a/package.json
+++ b/package.json
@@ -163,10 +163,15 @@
           "default": "origin",
           "description": "The remote branch for a repository."
         },
-        "githubinator.providers.github": {
+        "githubinator.providers.github.hostname": {
           "type": "string",
           "default": "github.com",
-          "description": "The hostname for identifying a github origin and building a url."
+          "description": "The hostname for identifying a Github origin and building a url."
+        },
+        "githubinator.providers.gitlab.hostname": {
+          "type": "string",
+          "default": "gitlab.com",
+          "description": "The hostname for identifying a Gitlab origin and building a url."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -143,18 +143,21 @@ async function githubinator({
       relativeFilePath: getRelativeFilePath(gitDir, fileName),
     })
     if (parsedUrl != null) {
+      console.log("Found provider", provider.name)
       url = parsedUrl.fileUrl
       repoUrl = parsedUrl.repoUrl
       break
     }
-  }
-  if (repoUrl != null && openRepo) {
-    vscode.env.openExternal(vscode.Uri.parse(repoUrl))
-    return
+    console.log("Skipping provider", provider.name)
   }
 
   if (url == null) {
-    return err("Could not create URL.")
+    return err("Could not find provider for repo.")
+  }
+
+  if (repoUrl != null && openRepo) {
+    vscode.env.openExternal(vscode.Uri.parse(repoUrl))
+    return
   }
 
   if (openUrl) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,10 +52,14 @@ const COMMANDS: [string, IGithubinator][] = [
 
 const DEFAULT_REMOTE = "origin"
 
+interface IProviderConfig {
+  hostname?: string
+}
+
 export interface IGithubinatorConfig {
   remote: string
   providers: {
-    [key: string]: string | undefined
+    [key: string]: IProviderConfig | undefined
   }
 }
 

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -74,7 +74,7 @@ export class Github implements IProvider {
   }
 }
 
-class Gitlab implements IProvider {
+export class Gitlab implements IProvider {
   DEFAULT_HOSTNAME = "gitlab.com"
   // https://gitlab.com/my_org/my_repo/blob/master/app/main.py#L3-4
   getMatchers(hostname: string) {

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -4,16 +4,20 @@ import { IGithubinatorConfig } from "./extension"
 import { cleanHostname } from "./utils"
 
 interface IGetUrl {
-  selection: [number, number]
-  head: string
-  mode: "blob" | "blame"
-  relativeFilePath: string
-  origin: string
-  providersConfig: IGithubinatorConfig["providers"]
+  readonly selection: [number, number]
+  readonly head: string
+  readonly mode: "blob" | "blame"
+  readonly relativeFilePath: string
+  readonly origin: string
+  readonly providersConfig: IGithubinatorConfig["providers"]
 }
 
+interface IUrlInfo {
+  readonly fileUrl: string
+  readonly repoUrl: string
+}
 interface IProvider {
-  getUrl(params: IGetUrl): { fileUrl: string; repoUrl: string } | null
+  readonly getUrl: (params: IGetUrl) => IUrlInfo | null
 }
 
 export class Github implements IProvider {
@@ -27,7 +31,7 @@ export class Github implements IProvider {
     mode,
     providersConfig,
     origin,
-  }: IGetUrl): { fileUrl: string; repoUrl: string } | null {
+  }: IGetUrl): IUrlInfo | null {
     const [start, end] = selection
     const ssh = origin.match(this.SSH)
     const https = origin.match(this.HTTPS)

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -57,4 +57,43 @@ export class Github implements IProvider {
   }
 }
 
-export const providers = [Github]
+class Gitlab implements IProvider {
+  SSH = /^git@gitlab\.com:(.*)\/(.*)\.git$/
+  HTTPS = /^https:\/\/gitlab.com\/(.*)\/(.*)\.git$/
+  HOSTNAME = "gitlab.com"
+  // https://gitlab.com/my_org/my_repo/blob/master/app/main.py#L3-4
+  getUrl({
+    selection,
+    relativeFilePath,
+    head,
+    mode,
+    providersConfig,
+    origin,
+  }: IGetUrl): IUrlInfo | null {
+    const ssh = origin.match(this.SSH)
+    const https = origin.match(this.HTTPS)
+    const [_, org, repo] = ssh ? ssh : https ? https : [null, null, null]
+    if (org == null || repo == null) {
+      return null
+    }
+
+    const providerHostname = providersConfig["gitlab"]
+    const hostname = cleanHostname(
+      providerHostname ? providerHostname : this.HOSTNAME,
+    )
+    const rootUrl = `https://${hostname}/`
+
+    const [start, end] = selection
+    // The format is L34-56 (this is one character off from Github)
+    const lines = `L${start + 1}-${end + 1}`
+    const repoUrl = new url.URL(path.join(org, repo), rootUrl)
+    const parsedUrl = new url.URL(
+      path.join(org, repo, mode, head, relativeFilePath),
+      rootUrl,
+    )
+    parsedUrl.hash = lines
+    return { fileUrl: parsedUrl.toString(), repoUrl: repoUrl.toString() }
+  }
+}
+
+export const providers = [Gitlab, Github]

--- a/src/test/providers.test.ts
+++ b/src/test/providers.test.ts
@@ -1,4 +1,4 @@
-import { Github } from "../providers"
+import { Github, Gitlab } from "../providers"
 import * as assert from "assert"
 
 test("Github", () => {
@@ -19,16 +19,52 @@ test("Github", () => {
   })
   test("https", () => {
     const result = gh.getUrl({
-      origin: "https://github.com/recipeyak/recipeyak.git",
+      origin: "https://gitlab.mycompany.com/recipeyak/recipeyak.git",
       selection: [17, 24],
       mode: "blame",
+      providersConfig: {
+        github: { hostname: "gitlab.mycompany.com" },
+      },
+      head: "db99a912f5c4bffe11d91e163cd78ed96589611b",
+      relativeFilePath: "frontend/src/components/App.ts",
+    })
+    assert.strictEqual(
+      result,
+      "https://gitlab.mycompany.com/recipeyak/recipeyak/blame/db99a912f5c4bffe11d91e163cd78ed96589611b/frontend/src/components/App.tsx#L17-L24",
+    )
+  })
+})
+
+test("Gitlab", () => {
+  const gl = new Gitlab()
+  test("ssh", () => {
+    const result = gl.getUrl({
+      origin: "git@gitlab.com:recipeyak/recipeyak.git",
+      selection: [17, 24],
+      mode: "blob",
       providersConfig: {},
       head: "db99a912f5c4bffe11d91e163cd78ed96589611b",
       relativeFilePath: "frontend/src/components/App.ts",
     })
     assert.strictEqual(
       result,
-      "https://github.com/recipeyak/recipeyak/blame/db99a912f5c4bffe11d91e163cd78ed96589611b/frontend/src/components/App.tsx#L17-L24",
+      "https://gitlab.com/recipeyak/recipeyak/blob/db99a912f5c4bffe11d91e163cd78ed96589611b/frontend/src/components/App.tsx#L17-L24",
+    )
+  })
+  test("https", () => {
+    const result = gl.getUrl({
+      origin: "https://gitlab.mycompany.com/recipeyak/recipeyak.git",
+      selection: [17, 24],
+      mode: "blame",
+      providersConfig: {
+        gitlab: { hostname: "gitlab.mycompany.com" },
+      },
+      head: "db99a912f5c4bffe11d91e163cd78ed96589611b",
+      relativeFilePath: "frontend/src/components/App.ts",
+    })
+    assert.strictEqual(
+      result,
+      "https://gitlab.mycompany.com/recipeyak/recipeyak/blame/db99a912f5c4bffe11d91e163cd78ed96589611b/frontend/src/components/App.tsx#L17-L24",
     )
   })
 })


### PR DESCRIPTION
### Added
- Gitlab provider with `githubinator.provider.gitlab.hostname` setting for configuring match

### Changed

- Github provider hostname is now configured with `githubinator.provider.github.hostname` setting instead of `githubinator.provider.github`.

### Fixed

- Fix regex creation for Github provider so hostname configured in settings is used to match origins.