### PR TITLE
Alter hostname configuration to support multiple hostnames per provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `githubinator.enable_context_menu` option to disable/enable access to githubinator in the context menu.
-- Gitlab provider with `githubinator.provider.gitlab.hostname` setting for configuring match.
+- Gitlab provider with `githubinator.provider.gitlab.hostnames` setting for configuring match.
 - Bitbucket provider and configuration.
 
 ### Changed
 
-- Github provider hostname is now configured with `githubinator.provider.github.hostname` setting instead of `githubinator.provider.github`.
+- Github provider hostnames are now configured with `githubinator.provider.github.hostnames` setting instead of `githubinator.provider.github`. This is now an array of hostnames instead of a single hostname. Note, the default for a provider will always be used for matching, so you cannot accidentally remove matching for `github.com` by only adding `mycompany.com` in `githubinator.provider.github.hostnames`.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ With `vsce` installed from NPM (`yarn global add vsce`), clone [this repo](https
 ## Extension Settings
 
 - `githubinator.default_remote`: The default remote branch for a repository. (default: `"origin"`)
-- `githubinator.providers.github.hostname`: The hostname for identifying a Github origin and building a URL. (default: `"github.com"`)
-- `githubinator.providers.gitlab.hostname`: The hostname for identifying a Gitlab origin and building a url. (default: `"gitlab.com"`)
+- `githubinator.providers.github.hostnames`: Hostnames for identifying a Github origin and building a URL. (default: `["github.com"]`)
+- `githubinator.providers.gitlab.hostnames`: Hostnames for identifying a Gitlab origin and building a url. (default: `["gitlab.com"]`)
+- `githubinator.providers.bitbucket.hostnames`: Hostnames for identifying a Bitbucket origin and building a url. (default: `["bitbucket.org"]`)
 
 ## Known Issues
 

--- a/package.json
+++ b/package.json
@@ -164,19 +164,34 @@
           "description": "The remote branch for a repository."
         },
         "githubinator.providers.github.hostname": {
-          "type": "string",
-          "default": "github.com",
-          "description": "The hostname for identifying a Github origin and building a url."
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "github.com"
+          ],
+          "description": "Hostnames for identifying a Github origin and building a url."
         },
         "githubinator.providers.gitlab.hostname": {
-          "type": "string",
-          "default": "gitlab.com",
-          "description": "The hostname for identifying a Gitlab origin and building a url."
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "gitlab.com"
+          ],
+          "description": "Hostnames for identifying a Gitlab origin and building a url."
         },
         "githubinator.providers.bitbucket.hostname": {
-          "type": "string",
-          "default": "bitbucket.org",
-          "description": "The hostname for identifying a Bitbucket origin and building a url."
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "bitbucket.org"
+          ],
+          "description": "Hostnames for identifying a Bitbucket origin and building a url."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,8 +52,8 @@ const COMMANDS: [string, IGithubinator][] = [
 
 const DEFAULT_REMOTE = "origin"
 
-interface IProviderConfig {
-  hostname?: string
+export interface IProviderConfig {
+  hostnames?: string[]
 }
 
 export interface IGithubinatorConfig {

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1,6 +1,6 @@
 import * as path from "path"
 import * as url from "url"
-import { IGithubinatorConfig } from "./extension"
+import { IGithubinatorConfig, IProviderConfig } from "./extension"
 import { cleanHostname } from "./utils"
 
 interface IGetUrl {
@@ -21,24 +21,43 @@ interface IProvider {
   readonly getUrls: (params: IGetUrl) => IUrlInfo | null
 }
 
+interface IOrgInfo {
+  org: string
+  repo: string
+  hostname: string
+}
 /** Match target against multiple matchers. Extract the first two groups. */
-function findOrgInfo(target: string, matchers: RegExp[]) {
-  const matches = matchers.map(matcher => target.match(matcher))
-  let org: string | null = null
-  let repo: string | null = null
-  for (const match of matches) {
-    if (match != null) {
-      ;[, org, repo] = match
+function findOrgInfo(
+  origin: string,
+  hostnames: string[],
+  getMatchers: (hostname: string) => RegExp[],
+): IOrgInfo | null {
+  for (const hostname of hostnames) {
+    const matches = getMatchers(hostname).map(matcher => origin.match(matcher))
+    let org: string | null = null
+    let repo: string | null = null
+    for (const match of matches) {
+      if (match != null) {
+        ;[, org, repo] = match
+      }
     }
+    if (org == null || repo == null) {
+      continue
+    }
+    return { org, repo, hostname }
   }
-  if (org == null || repo == null) {
-    return null
-  }
-  return { org, repo }
+  return null
+}
+
+function getHostnames(
+  defaults: string[],
+  config: undefined | IProviderConfig,
+): string[] {
+  return defaults.concat((config && config.hostnames) || []).map(cleanHostname)
 }
 
 export class Github implements IProvider {
-  DEFAULT_HOSTNAME = "github.com"
+  DEFAULT_HOSTNAMES = ["github.com"]
   getMatchers(hostname: string) {
     const SSH = RegExp(`^git@${hostname}:(.*)\/(.*)\.git$`)
     const HTTPS = RegExp(`^https:\/\/${hostname}\/(.*)\/(.*)\.git$`)
@@ -52,14 +71,15 @@ export class Github implements IProvider {
     origin,
   }: IGetUrl): IUrlInfo | null {
     const config = providersConfig["github"]
-    const providerHostname =
-      (config && config.hostname) || this.DEFAULT_HOSTNAME
-    const hostname = cleanHostname(providerHostname)
-    const repoInfo = findOrgInfo(origin, this.getMatchers(providerHostname))
+    // We always want to include the default hostnames, so a user cannot
+    // accidently remove github.com from the github provider by setting a custom
+    // hostname.
+    const hostnames = getHostnames(this.DEFAULT_HOSTNAMES, config)
+    const repoInfo = findOrgInfo(origin, hostnames, this.getMatchers.bind(this))
     if (repoInfo == null) {
       return null
     }
-    const rootUrl = `https://${hostname}/`
+    const rootUrl = `https://${repoInfo.hostname}/`
     const [start, end] = selection
     // Github uses 1-based indexing
     const lines = `L${start + 1}-L${end + 1}`
@@ -83,7 +103,7 @@ export class Github implements IProvider {
 }
 
 export class Gitlab implements IProvider {
-  DEFAULT_HOSTNAME = "gitlab.com"
+  DEFAULT_HOSTNAMES = ["gitlab.com"]
   // https://gitlab.com/my_org/my_repo/blob/master/app/main.py#L3-4
   getMatchers(hostname: string) {
     const SSH = RegExp(`^git@${hostname}:(.*)\/(.*)\.git$`)
@@ -98,14 +118,12 @@ export class Gitlab implements IProvider {
     origin,
   }: IGetUrl): IUrlInfo | null {
     const config = providersConfig["gitlab"]
-    const providerHostname =
-      (config && config.hostname) || this.DEFAULT_HOSTNAME
-    const hostname = cleanHostname(providerHostname)
-    const repoInfo = findOrgInfo(origin, this.getMatchers(providerHostname))
+    const hostnames = getHostnames(this.DEFAULT_HOSTNAMES, config)
+    const repoInfo = findOrgInfo(origin, hostnames, this.getMatchers.bind(this))
     if (repoInfo == null) {
       return null
     }
-    const rootUrl = `https://${hostname}/`
+    const rootUrl = `https://${repoInfo.hostname}/`
     const [start, end] = selection
     // The format is L34-56 (this is one character off from Github)
     const lines = `L${start + 1}-${end + 1}`
@@ -129,7 +147,7 @@ export class Gitlab implements IProvider {
 }
 
 export class Bitbucket implements IProvider {
-  DEFAULT_HOSTNAME = "bitbucket.org"
+  DEFAULT_HOSTNAMES = ["bitbucket.org"]
   getMatchers(hostname: string) {
     // git@bitbucket.org:recipeyak/recipeyak.git
     // https://chdsbd@bitbucket.org/recipeyak/recipeyak.git
@@ -145,15 +163,13 @@ export class Bitbucket implements IProvider {
     origin,
   }: IGetUrl): IUrlInfo | null {
     const config = providersConfig["bitbucket"]
-    const providerHostname =
-      (config && config.hostname) || this.DEFAULT_HOSTNAME
-    const hostname = cleanHostname(providerHostname)
-    const repoInfo = findOrgInfo(origin, this.getMatchers(providerHostname))
+    const hostnames = getHostnames(this.DEFAULT_HOSTNAMES, config)
+    const repoInfo = findOrgInfo(origin, hostnames, this.getMatchers.bind(this))
     if (repoInfo == null) {
       return null
     }
     // https://bitbucket.org/recipeyak/recipeyak/src/master/app/main.py#lines-12:15
-    const rootUrl = `https://${hostname}/`
+    const rootUrl = `https://${repoInfo.hostname}/`
     const [start, end] = selection
     const lines = `lines-${start + 1}:${end + 1}`
     const repoUrl = new url.URL(path.join(repoInfo.org, repoInfo.repo), rootUrl)

--- a/src/test/providers.test.ts
+++ b/src/test/providers.test.ts
@@ -25,7 +25,7 @@ suite("Github", () => {
       origin: "https://github.mycompany.com/recipeyak/recipeyak.git",
       selection: [17, 24],
       providersConfig: {
-        github: { hostname: "github.mycompany.com" },
+        github: { hostnames: ["github.mycompany.com"] },
       },
       head: "db99a912f5c4bffe11d91e163cd78ed96589611b",
       relativeFilePath: "frontend/src/components/App.tsx",
@@ -65,7 +65,7 @@ suite("Gitlab", () => {
       origin: "https://gitlab.mycompany.com/recipeyak/recipeyak.git",
       selection: [17, 24],
       providersConfig: {
-        gitlab: { hostname: "gitlab.mycompany.com" },
+        gitlab: { hostnames: ["gitlab.mycompany.com"] },
       },
       head: "db99a912f5c4bffe11d91e163cd78ed96589611b",
       relativeFilePath: "frontend/src/components/App.tsx",
@@ -106,7 +106,7 @@ suite("Bitbucket", () => {
       origin: "https://chdsbd@git.mycompany.org/recipeyak/recipeyak.git",
       selection: [17, 24],
       providersConfig: {
-        bitbucket: { hostname: "git.mycompany.org" },
+        bitbucket: { hostnames: ["git.mycompany.org"] },
       },
       head: "db99a912f5c4bffe11d91e163cd78ed96589611b",
       relativeFilePath: "frontend/src/components/App.tsx",


### PR DESCRIPTION
This allows for matching on multiple custom hostnames for a provider.
Note, the default for a provider will always be used for matching, so
you cannot accidentally remove matching for `github.com` by only adding
`gh.mycompany.com` in `githubinator.provider.github.hostnames`.