### PR TITLE
Fix handling of branch name argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use the `branch` argument to `githubinator`. Now the "... on master" commands
+  will lookup the master branch instead of using the current branch.
+
 ## 0.1.1 - 2019-03-02
 
 ### Added

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -118,7 +118,16 @@ async function githubinator({
   if (gitDir == null) {
     return err("Could not find .git directory.")
   }
-  const headBranch = await git.head(gitDir)
+  let headBranch: [string, string] | null = null
+  if (branch) {
+    const sha = await git.getSHAForBranch(gitDir, branch)
+    if (sha == null) {
+      return err(`Could not find SHA for branch name: ${branch}`)
+    }
+    headBranch = [sha, branch]
+  } else {
+    headBranch = await git.head(gitDir)
+  }
   if (headBranch == null) {
     return err("Could not find HEAD.")
   }


### PR DESCRIPTION
Use the `branch` argument to `githubinator`. Now the "... on master"
commands will lookup the master branch instead of using the current
branch.