### PR TITLE
Fixed failure when running Githubinator with detached HEAD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
           name: install
           command: |
             make install
+            sudo apt update
             sudo apt install libgtk-3-0 libxss1 libnss3 libasound2
       - save_cache:
           paths:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed failure when running Githubinator without a ref. When checking out a
+  SHA, Githubinator would fail because there wasn't a ref to work off.
+
 ## 0.2.1 - 2019-03-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed failure when running Githubinator without a ref. When checking out a
-  SHA, Githubinator would fail because there wasn't a ref to work off.
+- Fixed failure when running Githubinator with detached HEAD. Githubinator
+  would fail because there wasn't a ref to work off when running with a detached
+  HEAD.
 
 ## 0.2.1 - 2019-03-08
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -136,7 +136,7 @@ async function githubinator({
   if (gitDir == null) {
     return err("Could not find .git directory.")
   }
-  let headBranch: [string, string] | null = null
+  let headBranch: [string, string | null] | null = null
   if (branch) {
     const sha = await git.getSHAForBranch(gitDir, branch)
     if (sha == null) {
@@ -166,8 +166,13 @@ async function githubinator({
       remote => git.origin(gitDir, remote),
     ).getUrls({
       selection: [editor.selection.start.line, editor.selection.end.line],
-      // permalink > branch > branch from HEAD
-      head: !!permalink ? createSha(head) : createBranch(branchName),
+      // priority: permalink > branch > branch from HEAD
+      // If branchName could not be found (null) then we generate a permalink
+      // using the SHA.
+      head:
+        !!permalink || branchName == null
+          ? createSha(head)
+          : createBranch(branchName),
       relativeFilePath: getRelativeFilePath(gitDir, fileName),
     })
     if (parsedUrl != null) {


### PR DESCRIPTION
Githubinator would fail because there wasn't a ref to work off when running with a detached HEAD.