### PR TITLE
fix(extension): escape file paths

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -173,7 +173,11 @@ async function githubinator({
         !!permalink || branchName == null
           ? createSha(head)
           : createBranch(branchName),
-      relativeFilePath: getRelativeFilePath(gitDir, fileName),
+      // escape invalid url characters
+      // See https://github.com/chdsbd/vscode-githubinator/issues/28
+      relativeFilePath: encodeURIComponent(
+        getRelativeFilePath(gitDir, fileName),
+      ),
     })
     if (parsedUrl != null) {
       console.log("Found provider", provider.name)


### PR DESCRIPTION
Verify providers work with %2F in place of `/`
- [x] Github
- [x] Gitlab
- [x] Bitbucket
- [x] VisualStudio