### PR TITLE
revert: "fix(extension): escape file paths (#29)"

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -173,11 +173,7 @@ async function githubinator({
         !!permalink || branchName == null
           ? createSha(head)
           : createBranch(branchName),
-      // escape invalid url characters
-      // See https://github.com/chdsbd/vscode-githubinator/issues/28
-      relativeFilePath: encodeURIComponent(
-        getRelativeFilePath(gitDir, fileName),
-      ),
+      relativeFilePath: getRelativeFilePath(gitDir, fileName),
     })
     if (parsedUrl != null) {
       console.log("Found provider", provider.name)


### PR DESCRIPTION
This reverts commit 6ca4d5804875c28ca3c058b2531817f2c6ab1bad.

GH-28 should resolve this issue completely