### PR TITLE
support calling Githubinator without open files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.3.0 - 2020-08-15
+
+### Added
+
+- Support calling Githubinator without an open file.
+
+### Changed
+
+- Don't copy URL when using "Open PR".
+
 ## 0.2.3 - 2019-04-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ With `vsce` installed from NPM (`yarn global add vsce`), clone [this repo](https
 | `Githubinator: Blame Permalink`       |    ✅    |    ✅    | blame          | current sha    |
 | `Githubinator: Repository`            |    ✅    |    ✅    | open repo      | N/A            |
 | `Githubinator: History`               |    ✅    |    ✅    | open history   | N/A            |
-| `Githubinator: Open PR`               |    ✅    |    ✅    | open PR        | N/A            |
+| `Githubinator: Open PR`               |    ❌    |    ✅    | open PR        | N/A            |
 | `Githubinator: Compare`               |    ✅    |    ✅    | compare branch | N/A            |
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ With `vsce` installed from NPM (`yarn global add vsce`), clone [this repo](https
 
 ## Release Notes
 
+## 0.3.0
+
+- Support calling Githubinator without an open file.
+- Don't copy URL when using "Open PR".
+
 ## 0.2.3
 
 - Fix ref lookup to ensure most recent ref is always used.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "githubinator",
   "displayName": "Githubinator",
   "description": "Quickly open files on Github and other providers. View blame information, copy permalinks and more. See the \"commands\" section of the README for more details.",
-  "version": "0.3.0",
+  "version": "0.2.3",
   "publisher": "chdsbd",
   "license": "SEE LICENSE IN LICENSE",
   "icon": "images/logo256.png",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "githubinator",
   "displayName": "Githubinator",
   "description": "Quickly open files on Github and other providers. View blame information, copy permalinks and more. See the \"commands\" section of the README for more details.",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "publisher": "chdsbd",
   "license": "SEE LICENSE IN LICENSE",
   "icon": "images/logo256.png",

--- a/src/git.ts
+++ b/src/git.ts
@@ -101,7 +101,7 @@ function walkUpDirectories(
   file_path: string,
   file_or_folder: string,
 ): string | null {
-  let directory = path.dirname(file_path)
+  let directory = file_path
   while (true) {
     const newPath = path.resolve(directory, file_or_folder)
     if (fs.existsSync(newPath)) {

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -120,13 +120,16 @@ export class Github extends BaseProvider {
     const rootUrl = `https://${repoInfo.hostname}/`
     const [start, end] = selection
     // Github uses 1-based indexing
-    const lines = start != null && end != null ? `L${start + 1}-L${end + 1}` : null
+    const lines =
+      start != null && end != null ? `L${start + 1}-L${end + 1}` : null
     const repoUrl = new url.URL(
       path.join(repoInfo.org, repoInfo.repo),
       rootUrl,
     ).toString()
     const createUrl = (mode: string, hash = true) => {
-      if (relativeFilePath == null) {return null}
+      if (relativeFilePath == null) {
+        return null
+      }
       const u = new url.URL(
         path.join(
           repoInfo.org,
@@ -183,12 +186,16 @@ export class Gitlab extends BaseProvider {
     const rootUrl = `https://${repoInfo.hostname}/`
     const [start, end] = selection
     // The format is L34-56 (this is one character off from Github)
-    const lines = `L${start + 1}-${end + 1}`
+    const lines =
+      start != null && end != null ? `L${start + 1}-${end + 1}` : null
     const repoUrl = new url.URL(
       path.join(repoInfo.org, repoInfo.repo),
       rootUrl,
     ).toString()
     const createUrl = (mode: string, hash = true) => {
+      if (relativeFilePath == null) {
+        return null
+      }
       const u = new url.URL(
         path.join(
           repoInfo.org,
@@ -199,7 +206,7 @@ export class Gitlab extends BaseProvider {
         ),
         rootUrl,
       )
-      if (hash) {
+      if (hash && lines) {
         u.hash = lines
       }
       return u.toString()
@@ -247,12 +254,16 @@ export class Bitbucket extends BaseProvider {
     // https://bitbucket.org/recipeyak/recipeyak/src/master/app/main.py#lines-12:15
     const rootUrl = `https://${repoInfo.hostname}/`
     const [start, end] = selection
-    const lines = `lines-${start + 1}:${end + 1}`
+    const lines =
+      start != null && end != null ? `lines-${start + 1}:${end + 1}` : null
     const repoUrl = new url.URL(
       path.join(repoInfo.org, repoInfo.repo),
       rootUrl,
     ).toString()
     const createUrl = (mode: string, hash = true) => {
+      if (relativeFilePath == null) {
+        return null
+      }
       const u = new url.URL(
         path.join(
           repoInfo.org,
@@ -263,7 +274,7 @@ export class Bitbucket extends BaseProvider {
         ),
         rootUrl,
       )
-      if (hash) {
+      if (hash && lines) {
         u.hash = lines
       }
       return u.toString()
@@ -320,24 +331,32 @@ export class VisualStudio extends BaseProvider {
     // https://bitbucket.org/recipeyak/recipeyak/src/master/app/main.py#lines-12:15
     const rootUrl = `https://${repoInfo.hostname}/`
     const [start, end] = selection
-    const lines = `&line=${start + 1}&lineEnd=${end + 1}`
+    const lines =
+      start != null && end != null
+        ? `&line=${start + 1}&lineEnd=${end + 1}`
+        : null
     const repoUrl = new url.URL(
       path.join(repoInfo.org, "_git", repoInfo.repo),
       rootUrl,
     )
     let filePath = relativeFilePath
-    if (!filePath.startsWith("/")) {
+    if (filePath != null && !filePath.startsWith("/")) {
       filePath = "/" + filePath
     }
     const version =
       head.kind === "branch" ? `GB${head.value}` : `GC${head.value}`
-    const baseSearch = `path=${encodeURIComponent(filePath)}&version=${version}`
+    const baseSearch =
+      filePath != null
+        ? `path=${encodeURIComponent(filePath)}&version=${version}`
+        : null
     const blobUrl = new url.URL(repoUrl.toString())
     const blameUrl = new url.URL(repoUrl.toString())
     const historyUrl = new url.URL(repoUrl.toString())
-    blobUrl.search = baseSearch + lines
-    blameUrl.search = baseSearch + lines + "&_a=annotate"
-    historyUrl.search = baseSearch + "&_a=history"
+    if (baseSearch != null) {
+      blobUrl.search = baseSearch + lines
+      blameUrl.search = baseSearch + lines + "&_a=annotate"
+      historyUrl.search = baseSearch + "&_a=history"
+    }
     const compareUrl = new url.URL(
       path.join(repoInfo.org, "_git", repoInfo.repo, "branches"),
       rootUrl,

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -4,18 +4,18 @@ import { IProviderConfig } from "./extension"
 import { cleanHostname } from "./utils"
 
 interface IBaseGetUrls {
-  readonly selection: [number, number]
+  readonly selection: [number | null, number | null]
   readonly head: Head
-  readonly relativeFilePath: string
+  readonly relativeFilePath: string | null
 }
 
 export interface IUrlInfo {
-  readonly blobUrl: string
-  readonly repoUrl: string
-  readonly blameUrl: string
-  readonly historyUrl: string
-  readonly prUrl: string
-  readonly compareUrl: string
+  readonly blobUrl: string | null
+  readonly repoUrl: string | null
+  readonly blameUrl: string | null
+  readonly historyUrl: string | null
+  readonly prUrl: string | null
+  readonly compareUrl: string | null
 }
 
 interface IOrgInfo {
@@ -120,12 +120,13 @@ export class Github extends BaseProvider {
     const rootUrl = `https://${repoInfo.hostname}/`
     const [start, end] = selection
     // Github uses 1-based indexing
-    const lines = `L${start + 1}-L${end + 1}`
+    const lines = start != null && end != null ? `L${start + 1}-L${end + 1}` : null
     const repoUrl = new url.URL(
       path.join(repoInfo.org, repoInfo.repo),
       rootUrl,
     ).toString()
     const createUrl = (mode: string, hash = true) => {
+      if (relativeFilePath == null) {return null}
       const u = new url.URL(
         path.join(
           repoInfo.org,
@@ -136,7 +137,7 @@ export class Github extends BaseProvider {
         ),
         rootUrl,
       )
-      if (hash) {
+      if (hash && lines) {
         u.hash = lines
       }
       return u.toString()


### PR DESCRIPTION
This change allows Githubinator to function when there is no active text editor open. We fall back to the workspace information to find `.git/`.