### PR TITLE
reduce file count in bundle with esbuild

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,3 +8,4 @@ vsc-extension-quickstart.md
 **/tslint.json
 **/*.map
 **/*.ts
+node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- reduce package size by bundling extension with esbuild.
+
 ## 1.0.1 - 2021-04-17
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -291,7 +291,7 @@
   },
   "scripts": {
     "vscode:prepublish": "yarn run compile",
-    "compile": "tsc -p ./",
+    "compile": "yarn esbuild ./src/extension.ts --bundle --platform=node --external:vscode --outfile=out/extension.js",
     "watch": "tsc -watch -p ./",
     "postinstall": "node ./node_modules/vscode/bin/install",
     "lint": "yarn run tslint --project tsconfig.json",
@@ -305,6 +305,7 @@
     "@types/mocha": "^2.2.42",
     "@types/mz": "^0.0.32",
     "@types/node": "^10.12.21",
+    "esbuild": "^0.11.12",
     "prettier": "^1.16.4",
     "tslint": "^5.12.1",
     "typescript": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -290,8 +290,8 @@
     }
   },
   "scripts": {
-    "vscode:prepublish": "yarn run compile",
-    "compile": "yarn esbuild ./src/extension.ts --bundle --platform=node --external:vscode --outfile=out/extension.js",
+    "vscode:prepublish": "yarn esbuild ./src/extension.ts --bundle --platform=node --external:vscode --outfile=out/extension.js",
+    "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "postinstall": "node ./node_modules/vscode/bin/install",
     "lint": "yarn run tslint --project tsconfig.json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -204,6 +204,11 @@ es6-promisify@^5.0.0:
   dependencies:
     es6-promise "^4.0.3"
 
+esbuild@^0.11.12:
+  version "0.11.12"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.11.12.tgz#8cbe15bcb44212624c3e77c896a835f74dc71c3c"
+  integrity sha512-c8cso/1RwVj+fbDvLtUgSG4ZJQ0y9Zdrl6Ot/GAjyy4pdMCHaFnDMts5gqFnWRPLajWtEnI+3hlET4R9fVoZng==
+
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"


### PR DESCRIPTION
I was getting the following warning. Bundling the extension resolves this.
> This extension consists of 1127 files, out of which 1080 are JavaScript files. For performance reasons, you should bundle your extension: https://aka.ms/vscode-bundle-extension . You should also exclude unnecessary files by adding them to your .vscodeignore: https://aka.ms/vscode-vscodeignore