### PR TITLE
fix: compatibility with submodules

### DIFF
--- a/package.json
+++ b/package.json
@@ -291,7 +291,7 @@
   },
   "scripts": {
     "vscode:prepublish": "yarn esbuild ./src/extension.ts --bundle --platform=node --external:vscode --outfile=out/extension.js",
-    "compile": "tsc -p ./ && mkdir -p out/test/suite/test_submodule/ && cp src/test/suite/test_submodule/.git out/test/suite/test_submodule/",
+    "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "lint": "yarn run tslint --project tsconfig.json",
     "test": "yarn run compile && node ./out/test/runTest.js",

--- a/package.json
+++ b/package.json
@@ -291,7 +291,7 @@
   },
   "scripts": {
     "vscode:prepublish": "yarn esbuild ./src/extension.ts --bundle --platform=node --external:vscode --outfile=out/extension.js",
-    "compile": "tsc -p ./",
+    "compile": "tsc -p ./ && mkdir -p out/test/suite/test_submodule/ && cp src/test/suite/test_submodule/.git out/test/suite/test_submodule/",
     "watch": "tsc -watch -p ./",
     "lint": "yarn run tslint --project tsconfig.json",
     "test": "yarn run compile && node ./out/test/runTest.js",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -158,10 +158,15 @@ async function githubinator({
     return err("could not find file")
   }
 
-  const gitDir = git.dir(editorConfig.uri.fsPath)
-  if (gitDir == null) {
+  const gitDirectories = git.dir(editorConfig.uri.fsPath)
+
+  if (gitDirectories == null) {
     return err("Could not find .git directory.")
   }
+
+  const gitDir = gitDirectories.git
+  const repoDir = gitDirectories.repository
+
   let headBranch: [string, string | null] | null = null
   if (mainBranch) {
     const res = await findShaForBranches(gitDir)
@@ -204,7 +209,7 @@ async function githubinator({
           ? createSha(head)
           : createBranch(branchName),
       relativeFilePath: editorConfig.fileName
-        ? getRelativeFilePath(gitDir, editorConfig.fileName)
+        ? getRelativeFilePath(repoDir, editorConfig.fileName)
         : null,
     })
     if (parsedUrl != null) {

--- a/src/git.ts
+++ b/src/git.ts
@@ -113,7 +113,7 @@ function walkUpDirectories(
       if (fs.lstatSync(newPath).isFile()) {
         const submoduleMatch = fs
           .readFileSync(newPath, "utf8")
-          .match(/gitdir: (.+)\n/)
+          .match(/gitdir: (.+)/)
 
         if (submoduleMatch) {
           return {

--- a/src/git.ts
+++ b/src/git.ts
@@ -7,6 +7,11 @@ interface IRemote {
   url?: string
 }
 
+interface IGitDirectories {
+  git: string
+  repository: string
+}
+
 export async function origin(
   gitDir: string,
   remote: string,
@@ -100,12 +105,30 @@ export function dir(filePath: string) {
 function walkUpDirectories(
   file_path: string,
   file_or_folder: string,
-): string | null {
+): IGitDirectories | null {
   let directory = file_path
   while (true) {
     const newPath = path.resolve(directory, file_or_folder)
     if (fs.existsSync(newPath)) {
-      return newPath
+      if (fs.lstatSync(newPath).isFile()) {
+        const submoduleMatch = fs
+          .readFileSync(newPath, "utf8")
+          .match(/gitdir: (.+)\n/)
+
+        if (submoduleMatch) {
+          return {
+            git: path.resolve(path.join(directory, submoduleMatch[1])),
+            repository: directory,
+          }
+        } else {
+          return null
+        }
+      } else {
+        return {
+          git: newPath,
+          repository: directory,
+        }
+      }
     }
     const newDirectory = path.dirname(directory)
     if (newDirectory === directory) {

--- a/src/test/suite/git.test.ts
+++ b/src/test/suite/git.test.ts
@@ -1,0 +1,18 @@
+import { dir } from "../../git"
+import * as assert from "assert"
+import * as path from "path"
+
+suite("git", async () => {
+  test("dir", () => {
+    const repoPath = path.normalize(path.join(__dirname, "../../.."))
+
+    assert.strictEqual(dir(__dirname), path.join(repoPath, ".git"))
+    assert.strictEqual(dir(repoPath), path.join(repoPath, ".git"))
+
+    const submodulePath = path.join(__dirname, "test_submodule")
+    assert.strictEqual(
+      dir(submodulePath),
+      path.join(repoPath, ".git/modules/test_submodule"),
+    )
+  })
+})

--- a/src/test/suite/git.test.ts
+++ b/src/test/suite/git.test.ts
@@ -1,18 +1,30 @@
 import { dir } from "../../git"
 import * as assert from "assert"
 import * as path from "path"
+import * as fs from "fs"
 
 suite("git", async () => {
   test("dir", () => {
     const repoPath = path.normalize(path.join(__dirname, "../../.."))
+    const gitPath = path.join(repoPath, ".git")
 
-    assert.strictEqual(dir(__dirname), path.join(repoPath, ".git"))
-    assert.strictEqual(dir(repoPath), path.join(repoPath, ".git"))
+    assert.deepStrictEqual(dir(__dirname), {
+      git: gitPath,
+      repository: repoPath,
+    })
+    assert.deepStrictEqual(dir(repoPath), {
+      git: gitPath,
+      repository: repoPath,
+    })
 
+    const contents = "gitdir: ../../../../.git/modules/test_submodule"
     const submodulePath = path.join(__dirname, "test_submodule")
-    assert.strictEqual(
-      dir(submodulePath),
-      path.join(repoPath, ".git/modules/test_submodule"),
-    )
+    fs.mkdirSync(submodulePath, { recursive: true })
+    fs.writeFileSync(path.join(submodulePath, ".git"), contents)
+
+    assert.deepStrictEqual(dir(submodulePath), {
+      git: path.join(repoPath, ".git/modules/test_submodule"),
+      repository: submodulePath,
+    })
   })
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,12 @@
 import * as path from "path"
 import * as fs from "fs"
-/** Get path of file relative to git root. */
-export function getRelativeFilePath(gitDir: string, fileName: string): string {
+/** Get path of file relative to repository root. */
+export function getRelativeFilePath(
+  repositoryDir: string,
+  fileName: string,
+): string {
   const resolvedFileName = fs.realpathSync(fileName)
-  const gitProjectRoot = path.dirname(gitDir) + "/"
-  return resolvedFileName.replace(gitProjectRoot, "")
+  return resolvedFileName.replace(repositoryDir, "")
 }
 
 /** Convert url/hostname to hostname


### PR DESCRIPTION
Previously githubinator couldn't find git data for files inside a submodule.
Now it generates URLs, for the correct repositories.

There's a new test for `dir` function, but the actual blame URL generation was tested manually on https://github.com/discourse/all-the-plugins and its submodules.