### PR TITLE
fix: Actually use `mainBranches` setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2.0.1 - 2022-05-26
+
+### Fixed
+
+- `mainBranches` configuration option not being used. Thanks @CvX! (#56)
+
 ## 2.0.0 - 2021-12-09
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "githubinator",
   "displayName": "Githubinator",
   "description": "Quickly open files on Github and other providers. View blame information, copy permalinks and more. See the \"commands\" section of the README for more details.",
-  "version": "1.1.1",
+  "version": "2.0.1",
   "publisher": "chdsbd",
   "license": "SEE LICENSE IN LICENSE",
   "icon": "images/logo256.png",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -115,12 +115,16 @@ function getEditorInfo(): { uri: vscode.Uri | null; fileName: string | null } {
   return { uri, fileName }
 }
 
-const BRANCHES = ["main", "master", "trunk", "dev", "develop"]
+function mainBranches() {
+  return vscode.workspace
+    .getConfiguration("githubinator")
+    .get<string[]>("mainBranches", ["main"])
+}
 
 async function findShaForBranches(
   gitDir: string,
 ): Promise<[string, string] | null> {
-  for (let branch of BRANCHES) {
+  for (let branch of mainBranches()) {
     const sha = await git.getSHAForBranch(gitDir, branch)
     if (sha == null) {
       continue
@@ -171,7 +175,7 @@ async function githubinator({
   if (mainBranch) {
     const res = await findShaForBranches(gitDir)
     if (res == null) {
-      return err(`Could not find SHA for branch in ${BRANCHES}`)
+      return err(`Could not find SHA for branch in ${mainBranches()}`)
     }
     headBranch = res
   } else {


### PR DESCRIPTION
The setting was added in #39 but the code didn't actually use it and relied on the `BRANCHES` constant.