### PR TITLE
Submenu option for Githubinator commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2.1.0 - 2022-12-10
+
+### Changed
+
+- Replaced `enable_context_menu` with new option to allow configuring Githubinator to display context menu options in a submenu. Thanks @Far0n! (#58)
+
 ## 2.0.1 - 2022-05-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The "main" branch is configured via `githubinator.mainBranches` (see "Extension 
 
 ## Extension Settings
 
-- `githubinator.enable_context_menu`: Enable access to Githubinator commands from the context menu. (default: `true`)
+- `githubinator.contextMenu`: Enable access to Githubinator commands from the context menu (`"enabled"`|`"submenu"`|`"disabled"`). (default: `"enabled"`)
 - `githubinator.mainBranches`: Branch names to use as `main` repository branch. (default: `["main", "master", "trunk", "develop", "dev"]`)
 - `githubinator.remote`: The default remote branch for a repository. (default: `"origin"`)
 - `githubinator.providers.github.remote`: Remote name to look for when identifying a Github origin. (default: `"origin"`)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "githubinator",
   "displayName": "Githubinator",
   "description": "Quickly open files on Github and other providers. View blame information, copy permalinks and more. See the \"commands\" section of the README for more details.",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "publisher": "chdsbd",
   "license": "SEE LICENSE IN LICENSE",
   "icon": "images/logo256.png",

--- a/package.json
+++ b/package.json
@@ -124,82 +124,169 @@
         {
           "command": "extension.githubinator",
           "group": "githubinator@1",
-          "when": "config.githubinator.enable_context_menu"
+          "when": "config.githubinator.contextMenu == enabled"
         },
         {
           "command": "extension.githubinatorCopy",
           "group": "githubinator@2",
-          "when": "config.githubinator.enable_context_menu"
+          "when": "config.githubinator.contextMenu == enabled"
         },
         {
           "command": "extension.githubinatorCopyMaster",
           "group": "githubinator@3",
-          "when": "config.githubinator.enable_context_menu"
+          "when": "config.githubinator.contextMenu == enabled"
         },
         {
           "command": "extension.githubinatorCopyPermalink",
           "group": "githubinator@4",
-          "when": "config.githubinator.enable_context_menu"
+          "when": "config.githubinator.contextMenu == enabled"
         },
         {
           "command": "extension.githubinatorCopyMasterPermalink",
           "group": "githubinator@5",
-          "when": "config.githubinator.enable_context_menu"
+          "when": "config.githubinator.contextMenu == enabled"
         },
         {
           "command": "extension.githubinatorOnMaster",
           "group": "githubinator@6",
-          "when": "config.githubinator.enable_context_menu"
+          "when": "config.githubinator.contextMenu == enabled"
         },
         {
           "command": "extension.githubinatorPermalink",
           "group": "githubinator@7",
-          "when": "config.githubinator.enable_context_menu"
+          "when": "config.githubinator.contextMenu == enabled"
         },
         {
           "command": "extension.githubinatorBlame",
           "group": "githubinator@8",
-          "when": "config.githubinator.enable_context_menu"
+          "when": "config.githubinator.contextMenu == enabled"
         },
         {
           "command": "extension.githubinatorBlameOnMaster",
           "group": "githubinator@9",
-          "when": "config.githubinator.enable_context_menu"
+          "when": "config.githubinator.contextMenu == enabled"
         },
         {
           "command": "extension.githubinatorBlamePermalink",
           "group": "githubinator@10",
-          "when": "config.githubinator.enable_context_menu"
+          "when": "config.githubinator.contextMenu == enabled"
         },
         {
           "command": "extension.githubinatorRepository",
           "group": "githubinator@11",
-          "when": "config.githubinator.enable_context_menu"
+          "when": "config.githubinator.contextMenu == enabled"
         },
         {
           "command": "extension.githubinatorHistory",
           "group": "githubinator@12",
-          "when": "config.githubinator.enable_context_menu"
+          "when": "config.githubinator.contextMenu == enabled"
         },
         {
           "command": "extension.githubinatorOpenPR",
           "group": "githubinator@13",
-          "when": "config.githubinator.enable_context_menu"
+          "when": "config.githubinator.contextMenu == enabled"
         },
         {
           "command": "extension.githubinatorCompare",
           "group": "githubinator@14",
-          "when": "config.githubinator.enable_context_menu"
+          "when": "config.githubinator.contextMenu == enabled"
+        },
+        {
+          "submenu": "extension.githubinatorSubmenu",
+          "group": "githubinator@15"
+        }
+      ],
+      "extension.githubinatorSubmenu": [
+        {
+          "command": "extension.githubinator",
+          "group": "githubinator@1",
+          "when": "config.githubinator.contextMenu == submenu"
+        },
+        {
+          "command": "extension.githubinatorCopy",
+          "group": "githubinator@2",
+          "when": "config.githubinator.contextMenu == submenu"
+        },
+        {
+          "command": "extension.githubinatorCopyMaster",
+          "group": "githubinator@3",
+          "when": "config.githubinator.contextMenu == submenu"
+        },
+        {
+          "command": "extension.githubinatorCopyPermalink",
+          "group": "githubinator@4",
+          "when": "config.githubinator.contextMenu == submenu"
+        },
+        {
+          "command": "extension.githubinatorCopyMasterPermalink",
+          "group": "githubinator@5",
+          "when": "config.githubinator.contextMenu == submenu"
+        },
+        {
+          "command": "extension.githubinatorOnMaster",
+          "group": "githubinator@6",
+          "when": "config.githubinator.contextMenu == submenu"
+        },
+        {
+          "command": "extension.githubinatorPermalink",
+          "group": "githubinator@7",
+          "when": "config.githubinator.contextMenu == submenu"
+        },
+        {
+          "command": "extension.githubinatorBlame",
+          "group": "githubinator@8",
+          "when": "config.githubinator.contextMenu == submenu"
+        },
+        {
+          "command": "extension.githubinatorBlameOnMaster",
+          "group": "githubinator@9",
+          "when": "config.githubinator.contextMenu == submenu"
+        },
+        {
+          "command": "extension.githubinatorBlamePermalink",
+          "group": "githubinator@10",
+          "when": "config.githubinator.contextMenu == submenu"
+        },
+        {
+          "command": "extension.githubinatorRepository",
+          "group": "githubinator@11",
+          "when": "config.githubinator.contextMenu == submenu"
+        },
+        {
+          "command": "extension.githubinatorHistory",
+          "group": "githubinator@12",
+          "when": "config.githubinator.contextMenu == submenu"
+        },
+        {
+          "command": "extension.githubinatorOpenPR",
+          "group": "githubinator@13",
+          "when": "config.githubinator.contextMenu == submenu"
+        },
+        {
+          "command": "extension.githubinatorCompare",
+          "group": "githubinator@14",
+          "when": "config.githubinator.contextMenu == submenu"
         }
       ]
     },
+    "submenus": [
+      {
+        "label": "Githubinator",
+        "id": "extension.githubinatorSubmenu"
+      }
+    ],
     "configuration": {
       "type": "object",
       "title": "Githubinator",
       "properties": {
-        "githubinator.enable_context_menu": {
-          "type": "boolean",
-          "default": true,
+        "githubinator.contextMenu": {
+          "type": "string",
+          "enum": [
+            "enabled",
+            "submenu",
+            "disabled"
+          ],
+          "default": "enabled",
           "description": "Enable access to Githubinator commands from the context menu."
         },
         "githubinator.mainBranches": {

--- a/package.json
+++ b/package.json
@@ -279,6 +279,13 @@
       "type": "object",
       "title": "Githubinator",
       "properties": {
+        "githubinator.enable_context_menu": {
+          "type": "boolean",
+          "default": false,
+          "markdownDeprecationMessage": "**Deprecated**: Please use `#githubinator.contextMenu#` instead.",
+          "deprecationMessage": "Deprecated: Please use githubinator.contextMenu instead.",
+          "description": "Enable access to Githubinator commands from the context menu."
+        },
         "githubinator.contextMenu": {
           "type": "string",
           "enum": [

--- a/package.json
+++ b/package.json
@@ -124,72 +124,72 @@
         {
           "command": "extension.githubinator",
           "group": "githubinator@1",
-          "when": "config.githubinator.contextMenu == enabled"
+          "when": "config.githubinator.contextMenu == enabled && config.githubinator.contextMenuGithubinator"
         },
         {
           "command": "extension.githubinatorCopy",
           "group": "githubinator@2",
-          "when": "config.githubinator.contextMenu == enabled"
+          "when": "config.githubinator.contextMenu == enabled && config.githubinator.contextMenuCopy"
         },
         {
           "command": "extension.githubinatorCopyMaster",
           "group": "githubinator@3",
-          "when": "config.githubinator.contextMenu == enabled"
+          "when": "config.githubinator.contextMenu == enabled && config.githubinator.contextMenuCopyMaster"
         },
         {
           "command": "extension.githubinatorCopyPermalink",
           "group": "githubinator@4",
-          "when": "config.githubinator.contextMenu == enabled"
+          "when": "config.githubinator.contextMenu == enabled && config.githubinator.contextMenuCopyPermalink"
         },
         {
           "command": "extension.githubinatorCopyMasterPermalink",
           "group": "githubinator@5",
-          "when": "config.githubinator.contextMenu == enabled"
+          "when": "config.githubinator.contextMenu == enabled && config.githubinator.contextMenuCopyMasterPermalink"
         },
         {
           "command": "extension.githubinatorOnMaster",
           "group": "githubinator@6",
-          "when": "config.githubinator.contextMenu == enabled"
+          "when": "config.githubinator.contextMenu == enabled && config.githubinator.contextMenuOnMaster"
         },
         {
           "command": "extension.githubinatorPermalink",
           "group": "githubinator@7",
-          "when": "config.githubinator.contextMenu == enabled"
+          "when": "config.githubinator.contextMenu == enabled && config.githubinator.contextMenuPermalink"
         },
         {
           "command": "extension.githubinatorBlame",
           "group": "githubinator@8",
-          "when": "config.githubinator.contextMenu == enabled"
+          "when": "config.githubinator.contextMenu == enabled && config.githubinator.contextMenuBlame"
         },
         {
           "command": "extension.githubinatorBlameOnMaster",
           "group": "githubinator@9",
-          "when": "config.githubinator.contextMenu == enabled"
+          "when": "config.githubinator.contextMenu == enabled && config.githubinator.contextMenuBlameOnMaster"
         },
         {
           "command": "extension.githubinatorBlamePermalink",
           "group": "githubinator@10",
-          "when": "config.githubinator.contextMenu == enabled"
+          "when": "config.githubinator.contextMenu == enabled && config.githubinator.contextMenuBlamePermalink"
         },
         {
           "command": "extension.githubinatorRepository",
           "group": "githubinator@11",
-          "when": "config.githubinator.contextMenu == enabled"
+          "when": "config.githubinator.contextMenu == enabled && config.githubinator.contextMenuRepository"
         },
         {
           "command": "extension.githubinatorHistory",
           "group": "githubinator@12",
-          "when": "config.githubinator.contextMenu == enabled"
+          "when": "config.githubinator.contextMenu == enabled && config.githubinator.contextMenuHistory"
         },
         {
           "command": "extension.githubinatorOpenPR",
           "group": "githubinator@13",
-          "when": "config.githubinator.contextMenu == enabled"
+          "when": "config.githubinator.contextMenu == enabled && config.githubinator.contextMenuOpenPR"
         },
         {
           "command": "extension.githubinatorCompare",
           "group": "githubinator@14",
-          "when": "config.githubinator.contextMenu == enabled"
+          "when": "config.githubinator.contextMenu == enabled && config.githubinator.contextMenuCompare"
         },
         {
           "submenu": "extension.githubinatorSubmenu",
@@ -200,72 +200,72 @@
         {
           "command": "extension.githubinator",
           "group": "githubinator@1",
-          "when": "config.githubinator.contextMenu == submenu"
+          "when": "config.githubinator.contextMenu == submenu && config.githubinator.contextMenuGithubinator"
         },
         {
           "command": "extension.githubinatorCopy",
           "group": "githubinator@2",
-          "when": "config.githubinator.contextMenu == submenu"
+          "when": "config.githubinator.contextMenu == submenu && config.githubinator.contextMenuCopy"
         },
         {
           "command": "extension.githubinatorCopyMaster",
           "group": "githubinator@3",
-          "when": "config.githubinator.contextMenu == submenu"
+          "when": "config.githubinator.contextMenu == submenu && config.githubinator.contextMenuCopyMaster"
         },
         {
           "command": "extension.githubinatorCopyPermalink",
           "group": "githubinator@4",
-          "when": "config.githubinator.contextMenu == submenu"
+          "when": "config.githubinator.contextMenu == submenu && config.githubinator.contextMenuCopyPermalink"
         },
         {
           "command": "extension.githubinatorCopyMasterPermalink",
           "group": "githubinator@5",
-          "when": "config.githubinator.contextMenu == submenu"
+          "when": "config.githubinator.contextMenu == submenu && config.githubinator.contextMenuCopyMasterPermalink"
         },
         {
           "command": "extension.githubinatorOnMaster",
           "group": "githubinator@6",
-          "when": "config.githubinator.contextMenu == submenu"
+          "when": "config.githubinator.contextMenu == submenu && config.githubinator.contextMenuOnMaster"
         },
         {
           "command": "extension.githubinatorPermalink",
           "group": "githubinator@7",
-          "when": "config.githubinator.contextMenu == submenu"
+          "when": "config.githubinator.contextMenu == submenu && config.githubinator.contextMenuPermalink"
         },
         {
           "command": "extension.githubinatorBlame",
           "group": "githubinator@8",
-          "when": "config.githubinator.contextMenu == submenu"
+          "when": "config.githubinator.contextMenu == submenu && config.githubinator.contextMenuBlame"
         },
         {
           "command": "extension.githubinatorBlameOnMaster",
           "group": "githubinator@9",
-          "when": "config.githubinator.contextMenu == submenu"
+          "when": "config.githubinator.contextMenu == submenu && config.githubinator.contextMenuBlameOnMaster"
         },
         {
           "command": "extension.githubinatorBlamePermalink",
           "group": "githubinator@10",
-          "when": "config.githubinator.contextMenu == submenu"
+          "when": "config.githubinator.contextMenu == submenu && config.githubinator.contextMenuBlamePermalink"
         },
         {
           "command": "extension.githubinatorRepository",
           "group": "githubinator@11",
-          "when": "config.githubinator.contextMenu == submenu"
+          "when": "config.githubinator.contextMenu == submenu && config.githubinator.contextMenuRepository"
         },
         {
           "command": "extension.githubinatorHistory",
           "group": "githubinator@12",
-          "when": "config.githubinator.contextMenu == submenu"
+          "when": "config.githubinator.contextMenu == submenu && config.githubinator.contextMenuHistory"
         },
         {
           "command": "extension.githubinatorOpenPR",
           "group": "githubinator@13",
-          "when": "config.githubinator.contextMenu == submenu"
+          "when": "config.githubinator.contextMenu == submenu && config.githubinator.contextMenuOpenPR"
         },
         {
           "command": "extension.githubinatorCompare",
           "group": "githubinator@14",
-          "when": "config.githubinator.contextMenu == submenu"
+          "when": "config.githubinator.contextMenu == submenu && config.githubinator.contextMenuCompare"
         }
       ]
     },
@@ -287,7 +287,92 @@
             "disabled"
           ],
           "default": "enabled",
+          "order": 0,
           "description": "Enable access to Githubinator commands from the context menu."
+        },
+        "githubinator.contextMenuGithubinator": {
+          "type": "boolean",
+          "default": "true",
+          "order": 1,
+          "markdownDescription": "Access command **Githubinator** via context menu."
+        },
+        "githubinator.contextMenuCopy": {
+          "type": "boolean",
+          "default": "true",
+          "order": 2,
+          "markdownDescription": "Access command **Copy** via context menu."
+        },
+        "githubinator.contextMenuCopyMaster": {
+          "type": "boolean",
+          "default": "true",
+          "order": 3,
+          "markdownDescription": "Access command **Copy Main** via context menu."
+        },
+        "githubinator.contextMenuCopyPermalink": {
+          "type": "boolean",
+          "default": "true",
+          "order": 4,
+          "markdownDescription": "Access command **Copy Permalink** via context menu."
+        },
+        "githubinator.contextMenuCopyMasterPermalink": {
+          "type": "boolean",
+          "default": "true",
+          "order": 5,
+          "markdownDescription": "Access command **Copy Main Permalink** via context menu."
+        },
+        "githubinator.contextMenuOnMaster": {
+          "type": "boolean",
+          "default": "true",
+          "order": 6,
+          "markdownDescription": "Access command **On Main** via context menu."
+        },
+        "githubinator.contextMenuPermalink": {
+          "type": "boolean",
+          "default": "true",
+          "order": 7,
+          "markdownDescription": "Access command **Permalink** via context menu."
+        },
+        "githubinator.contextMenuBlame": {
+          "type": "boolean",
+          "default": "true",
+          "order": 8,
+          "markdownDescription": "Access command **Blame** via context menu."
+        },
+        "githubinator.contextMenuBlameOnMaster": {
+          "type": "boolean",
+          "default": "true",
+          "order": 9,
+          "markdownDescription": "Access command **Blame On Main** via context menu."
+        },
+        "githubinator.contextMenuBlamePermalink": {
+          "type": "boolean",
+          "default": "true",
+          "order": 10,
+          "markdownDescription": "Access command **Blame Permalink** via context menu."
+        },
+        "githubinator.contextMenuRepository": {
+          "type": "boolean",
+          "default": "true",
+          "order": 11,
+          "markdownDescription": "Access command **Repository** via context menu."
+        },
+        "githubinator.contextMenuHistory": {
+          "type": "boolean",
+          "default": "true",
+          "order": 12,
+          "markdownDescription": "Access command **History** via context menu."
+        },
+        "githubinator.contextMenuOpenPR": {
+          "type": "boolean",
+          "default": "true",
+          "order": 13,
+          "markdownDescription": "Access command **OpenPR** via context menu."
+        },
+        "githubinator.contextMenuCompare": {
+          "type": "boolean",
+          "default": "true",
+          "order": 14,
+          "markdownDescription": "Access command **Compare** via context menu."
         },
         "githubinator.mainBranches": {
           "type": "array",


### PR DESCRIPTION
- Replaces the boolean setting `enable_context_menu` with dropdown `contextMenu` with three options:
  - `enabled`: same as `enable_context_menu = true`
  - `submenu`: puts all commands into a submenu "Githubinator"
  - `disabled`: same as `enable_context_menu = false`
- Adds a toggle for each command to specify whether it is shown in the context menu

![grafik](https://user-images.githubusercontent.com/6949295/205152328-20377c78-94f0-45de-b375-3f8f1e1b0be5.png)


- Related issue: #57