### PR TITLE
rename "Open PR" to "Open Pull Request"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 3.0.0 - 2023-04-19
+
+### Changed
+
+- Renamed "Open PR" to "Open Pull Request".
+
 ## 2.1.0 - 2022-12-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -26,22 +26,22 @@ With `vsce` installed from NPM (`yarn global add vsce`), clone [this repo](https
 
 ### Commands
 
-| command                             | copy URL | open URL | mode           | SHA-type       |
-| ----------------------------------- | :------: | :------: | -------------- | -------------- |
-| `Githubinator`                      |    ✅    |    ❌    | blob           | current branch |
-| `Githubinator: Copy`                |    ✅    |    ❌    | blob           | current branch |
-| `Githubinator: Copy Main`           |    ✅    |    ❌    | blob           | "main" branch  |
-| `Githubinator: Copy Permalink`      |    ✅    |    ❌    | blob           | current SHA    |
-| `Githubinator: Copy Main Permalink` |    ✅    |    ❌    | blob           | "main" SHA     |
-| `Githubinator: On Main`             |    ✅    |    ✅    | blob           | "main" branch  |
-| `Githubinator: Permalink`           |    ✅    |    ✅    | blob           | current SHA    |
-| `Githubinator: Blame`               |    ✅    |    ✅    | blame          | current branch |
-| `Githubinator: Blame On Main`       |    ✅    |    ✅    | blame          | "main" branch  |
-| `Githubinator: Blame Permalink`     |    ✅    |    ✅    | blame          | current sha    |
-| `Githubinator: Repository`          |    ✅    |    ✅    | open repo      | N/A            |
-| `Githubinator: History`             |    ✅    |    ✅    | open history   | N/A            |
-| `Githubinator: Open PR`             |    ❌    |    ✅    | open PR        | N/A            |
-| `Githubinator: Compare`             |    ✅    |    ✅    | compare branch | N/A            |
+| command                             | copy URL | open URL | mode              | SHA-type       |
+| ----------------------------------- | :------: | :------: | ----------------- | -------------- |
+| `Githubinator`                      |    ✅    |    ❌    | blob              | current branch |
+| `Githubinator: Copy`                |    ✅    |    ❌    | blob              | current branch |
+| `Githubinator: Copy Main`           |    ✅    |    ❌    | blob              | "main" branch  |
+| `Githubinator: Copy Permalink`      |    ✅    |    ❌    | blob              | current SHA    |
+| `Githubinator: Copy Main Permalink` |    ✅    |    ❌    | blob              | "main" SHA     |
+| `Githubinator: On Main`             |    ✅    |    ✅    | blob              | "main" branch  |
+| `Githubinator: Permalink`           |    ✅    |    ✅    | blob              | current SHA    |
+| `Githubinator: Blame`               |    ✅    |    ✅    | blame             | current branch |
+| `Githubinator: Blame On Main`       |    ✅    |    ✅    | blame             | "main" branch  |
+| `Githubinator: Blame Permalink`     |    ✅    |    ✅    | blame             | current sha    |
+| `Githubinator: Repository`          |    ✅    |    ✅    | open repo         | N/A            |
+| `Githubinator: History`             |    ✅    |    ✅    | open history      | N/A            |
+| `Githubinator: Open Pull Request`   |    ❌    |    ✅    | open pull request | N/A            |
+| `Githubinator: Compare`             |    ✅    |    ✅    | compare branch    | N/A            |
 
 The "main" branch is configured via `githubinator.mainBranches` (see "Extension Settings" below).
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "githubinator",
   "displayName": "Githubinator",
   "description": "Quickly open files on Github and other providers. View blame information, copy permalinks and more. See the \"commands\" section of the README for more details.",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "publisher": "chdsbd",
   "license": "SEE LICENSE IN LICENSE",
   "icon": "images/logo256.png",
@@ -110,7 +110,7 @@
       },
       {
         "command": "extension.githubinatorOpenPR",
-        "title": "Open PR",
+        "title": "Open Pull Request",
         "category": "Githubinator"
       },
       {


### PR DESCRIPTION
"Open PR" will still match against "Open Pull Request", so this shouldn't break any user workflows