### PR TITLE
fix vscode engine version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/chdsbd/vscode-githubinator/issues"
   },
   "engines": {
-    "vscode": "^1.89.0"
+    "vscode": "^1.110.0"
   },
   "categories": [
     "Other"


### PR DESCRIPTION
```
ERROR  @types/vscode ^1.110.0 greater than engines.vscode ^1.89.0. Either upgrade engines.vscode or use an older @types/vscode version
```